### PR TITLE
Do not print fully qualified argument symbols.

### DIFF
--- a/src/sphinxcontrib.cldomain.lisp
+++ b/src/sphinxcontrib.cldomain.lisp
@@ -297,7 +297,7 @@ possible symbol names."
     (simplify-arglist (arglist symbol))))
   (encode-object-member
    'arguments
-   (format nil "~S" (arglist symbol))))
+   (format nil "~A" (arglist symbol))))
 
 (defun encode-variable-documentation* (symbol type)
   (encode-object-member


### PR DESCRIPTION
Printing with `~S` gives a `READ`able list. We don't need that.
Fixes #1 